### PR TITLE
Better apiRule wait in app-push

### DIFF
--- a/app-push/action.yml
+++ b/app-push/action.yml
@@ -197,8 +197,8 @@ runs:
         virtualservice_url=""
         if [[ "${EXPOSE}" == "true" ]]; then
           echo "waiting 30s for APIRule to be ready..."
-          kubectl wait --for=jsonpath='{.spec.hosts}' virtualservices.networking.istio.io -l "apirule.gateway.kyma-project.io/v1beta1=${NAME}.${NAMESPACE}" -n "${NAMESPACE}" --timeout=30s
-          virtualservice_url="$(kubectl get virtualservices.networking.istio.io  -n "${NAMESPACE}" -l "apirule.gateway.kyma-project.io/v1beta1=${NAME}.${NAMESPACE}" -o "jsonpath={.items[0].spec.hosts[]}")"
+          kubectl wait --for=jsonpath='{.spec.hosts}' virtualservices.networking.istio.io -l "apirule.gateway.kyma-project.io/name=${NAME}" -n "${NAMESPACE}" --timeout=30s
+          virtualservice_url="$(kubectl get virtualservices.networking.istio.io  -n "${NAMESPACE}" -l "apirule.gateway.kyma-project.io/name=${NAME}" -o "jsonpath={.items[0].spec.hosts[]}")"
           echo "url=${virtualservice_url}" >> $GITHUB_OUTPUT
 
           echo "# Application deployed :rocket:" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Better apiRule wait in app-push
    - timeout after 30s
    - add simple log message to see if `kyma app-push` is stuck or the VirtualService detection
    - adjust labels for the v2 apiRules

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/cli/issues/2628