### PR TITLE
Remove pull_request_target trigger to prevent pull-request vulnerability

### DIFF
--- a/.github/workflows/app-push-test.yml
+++ b/.github/workflows/app-push-test.yml
@@ -4,8 +4,6 @@ on:
     branches:
       - main
       - release-*
-  pull_request_target:
-    types: [opened, edited, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read
@@ -15,9 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: "get Kyma cli"
         uses: ./
       - name: "get kubeconfig"


### PR DESCRIPTION
## Summary
- Removes `pull_request_target` trigger from `app-push-test.yml` workflow
- Removes PR-context checkout params (`head.ref`, `head.repo.full_name`) that are no longer needed
- Workflow now runs only on push to `main` and `release-*` branches

## Security issue fixed
`pull_request_target` runs with access to repository secrets and OIDC token. The workflow was checking out and executing untrusted code from fork PRs (`uses: ./`, `uses: ./kubeconfig`, `uses: ./app-push`), allowing a malicious PR to exfiltrate `secrets.SERVER`, `secrets.CA_CRT`, and the OIDC-derived kubeconfig (full cluster access).

## Trade-off
Integration test no longer runs as a pre-merge gate. It runs post-merge on `main`/`release-*` pushes, where the code is trusted.